### PR TITLE
Add viewport meta tag to HTML head

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -3,6 +3,7 @@
 
 <head>
     <title>@ViewData["Title"]</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script type="text/javascript" src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>


### PR DESCRIPTION
Much better page dimensions and scaling on mobile devices; this tag is standard practice for HTML these days.

Also see https://github.com/heroku/php-getting-started/pull/74

GUS-W-16610879