### PR TITLE
Apply database migrations at runtime

### DIFF
--- a/Frontend/Program.cs
+++ b/Frontend/Program.cs
@@ -25,6 +25,12 @@ builder.Services.AddDbContext<GettingStartedMovieContext>(options =>
 
 var app = builder.Build();
 
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<GettingStartedMovieContext>();
+    db.Database.Migrate();
+}
+
 app.UseForwardedHeaders();
 
 if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
While this approach isn't ideal for production apps (for some of the [reasons listed here](https://learn.microsoft.com/en-us/ef/core/managing-schemas/migrations/applying?tabs=dotnet-core-cli#apply-migrations-at-runtime)), this change allows for easier testing until a better solution is supported.