### PR TITLE
Use relative path to define web process type

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: cd /workspace/Frontend/bin/publish/; ./Frontend --urls http://0.0.0.0:$PORT
+web: cd Frontend/bin/publish/; ./Frontend --urls http://0.0.0.0:$PORT


### PR DESCRIPTION
This increases `Procfile` compatibility by relying on the current working directory when executing commands.

For instance, Heroku will run commands from the `/app` working directory, while the working directory will be the default CNB application directory `/workspace` (at least when using `buildpacks-procfile`, which doesn't support setting a working directory).