### PR TITLE
Always use postgres database

### DIFF
--- a/Frontend/Frontend.csproj
+++ b/Frontend/Frontend.csproj
@@ -12,7 +12,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SQLite" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Frontend/Program.cs
+++ b/Frontend/Program.cs
@@ -12,15 +12,8 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 });
 builder.Services.AddDbContext<GettingStartedMovieContext>(options =>
 {
-    if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Production")
-    {
-        var match = Regex.Match(Environment.GetEnvironmentVariable("DATABASE_URL")!, @"postgres://(.*):(.*)@(.*):(.*)/(.*)");
-        options.UseNpgsql($"Server={match.Groups[3]};Port={match.Groups[4]};User Id={match.Groups[1]};Password={match.Groups[2]};Database={match.Groups[5]};sslmode=Prefer;Trust Server Certificate=true");
-    }
-    else
-    {
-        options.UseSqlite(builder.Configuration.GetConnectionString("GettingStartedMovieContext") ?? throw new InvalidOperationException("Connection string 'GettingStartedMovieContext' not found."));
-    }
+    var match = Regex.Match(Environment.GetEnvironmentVariable("DATABASE_URL")!, @"postgres://(.*):(.*)@(.*):(.*)/(.*)");
+    options.UseNpgsql($"Server={match.Groups[3]};Port={match.Groups[4]};User Id={match.Groups[1]};Password={match.Groups[2]};Database={match.Groups[5]};sslmode=Prefer;Trust Server Certificate=true");
 });
 
 var app = builder.Build();

--- a/Frontend/Program.cs
+++ b/Frontend/Program.cs
@@ -18,12 +18,6 @@ builder.Services.AddDbContext<GettingStartedMovieContext>(options =>
 
 var app = builder.Build();
 
-using (var scope = app.Services.CreateScope())
-{
-    var db = scope.ServiceProvider.GetRequiredService<GettingStartedMovieContext>();
-    db.Database.Migrate();
-}
-
 app.UseForwardedHeaders();
 
 if (!app.Environment.IsDevelopment())

--- a/Frontend/appsettings.json
+++ b/Frontend/appsettings.json
@@ -5,8 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "GettingStartedMovieContext": "Data Source=GettingStartedMovieContext-1720df23-c501-4baa-bfb6-638624863531.db"
-  }
+  "AllowedHosts": "*"
 }


### PR DESCRIPTION
This PR removes the dependency on a development sqlite database, and removes the logic to apply database migrations during app startup.

To use the `/movies` endpoint on the `Frontend` app, a `DATABASE_URL` must now be specified.