### PR TITLE
Define docker compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  frontend:
+    image: my-dotnet-app
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: 8080
+      DATABASE_URL: postgres://foo:bar@db:5432/moviedb
+    depends_on:
+      - db
+
+  db:
+    image: postgres:latest
+    restart: always
+    environment:
+      POSTGRES_USER: foo
+      POSTGRES_PASSWORD: bar
+      POSTGRES_DB: moviedb
+    ports:
+      - "5432:5432"


### PR DESCRIPTION
This PR adds a simple Docker compose configuration to let users easily run the application and Postgres database (without requiring Postgres or the .NET SDK to be installed locally):

```
pack build my-dotnet-app --builder heroku/builder:24
docker-compose up
docker-compose run --rm frontend -- Frontend/bin/publish/efbundle
```

This largely resembles the steps users would take when deploying the app to Heroku (classic):

```
heroku apps:create
git push heroku main
heroku addons:create heroku-postgresql:essential-0
heroku run Frontend/bin/publish/efbundle
```

A few notes on some of the commands in the docker compose example:
* It would perhaps be nice to let `docker-compose up` handle all the setup tasks, including building the `my-dotnet-app` image and running database migrations. However:
    * I don't think it's actually possible to build an app image using `pack` that can immediately be used by the `frontend` service?
        
        While it's certainly possible to add a `build` service to the compose configuration that builds the image, and let the `frontend` service depend on that ([ensuring it's not started before the build has completed](https://docs.docker.com/reference/compose-file/services/#long-syntax-1)), it will still (as far as I'm aware) require running `docker-compose up` twice to actually use that image for the `frontend` service.
    
        The key here is that we're not using a `Dockerfile` to build the image.
* It'd be straightforward to add a `dbmigrate` service to the compose configuration. However, it's probably preferable to keep this as a separate step, as that's also how users will apply database migrations on Heroku.
* Running `pack build my-dotnet-app` directly, or in a container?
    * It's of course possible to build the image in a container:
    ```
    docker run --rm \
      -e PACK_VOLUME_KEY=foobar \
      -v "$(pwd):/workspace" \
      -v /var/run/docker.sock:/var/run/docker.sock \
      -w /workspace \
      buildpacksio/pack \
      build my-dotnet-app --builder heroku/builder:24
    ```
    * There are several potential issues related to this though. For one, if running in an environment where Docker Desktop is used on the host and in an [organization that enforces sign-in](https://docs.docker.com/security/for-admins/enforce-sign-in/), such as Salesforce, the `heroku/builder:24` image will have to be pulled beforehand (as the containerized `pack` command will be interacting with the host’s docker socket, without being authenticated, with `--pull-policy never` set to avoid authentication failures). So the above instructions would have to account for that:
    ```
    docker pull heroku/builder:24 // Ensure the builder is available on the local Docker daemon
    docker run --rm \
      -e PACK_VOLUME_KEY=foobar \
      -v "$(pwd):/workspace" \
      -v /var/run/docker.sock:/var/run/docker.sock \
      -w /workspace \
      buildpacksio/pack \
      build my-dotnet-app --builder heroku/builder:24 --pull-policy never
    ```
    * The above commands examples enable the containerized `pack` command to interact with the host using the `/var/run/docker.sock` socket, and mounts the current directory using `$(pwd)`. There may be workarounds for this, but those commands will likely not work as expected using the [default Windows command prompt](https://en.wikipedia.org/wiki/Cmd.exe).
    * Ultimately, unless there are elegant solutions to the above issues, requiring `pack` to be installed seems reasonable considering how easy it is to install across platforms and the many caveats that'd otherwise have to be documented and accounted for (though adding a couple platform-specific scripts could also help bridge the gap).
* Running `docker-compose run --rm frontend -- Frontend/bin/publish/efbundle`:
    * Is a bit of a hack. It's a short command that achieves a couple goals:
        * It inherits the `DATABASE_URL` env var configuration from the `frontend` service.
        * It ensures that `DOTNET_ROOT`, which is set by the buildpack (and required by the `efbundle` executable), is configured by the CNB launcher/lifecycle.
        * It allows the command to be executed in the default compose network context.
    * In documentation, it'd arguably be cleaner to suggest a plain `docker run` command that doesn't use the `frontend` service this way, e.g. something like:
    ```
    docker run --rm \
      -e "DATABASE_URL=postgres://foo:bar@db:5432/moviedb" \
      --network dotnet-getting-started_default \
      my-dotnet-app Frontend/bin/publish/efbundle 
    ```
    * The `DATABASE_URL` environment variable could of course also be shared between the `frontend` Docker compose service, and used by this command (in addition to supporting `heroku local` uses out of the box) with an `.env` file, e.g.:
    ```
    docker run --rm \
      --env-file .env \
      --network dotnet-getting-started_default \
      my-dotnet-app Frontend/bin/publish/efbundle
    ```