### PR TITLE
Use wildcard host address

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: cd Frontend/bin/publish/; ./Frontend --urls http://0.0.0.0:$PORT
+web: cd Frontend/bin/publish/; ./Frontend --urls http://*:$PORT


### PR DESCRIPTION
This allows Kestrel to bind to all IPv6 as well as IPv4 addresses