### PR TITLE
Configure forwarded and redirect headers for Heroku

### DIFF
--- a/Frontend/Program.cs
+++ b/Frontend/Program.cs
@@ -10,6 +10,14 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
 });
+builder.Services.AddHttpsRedirection(options =>
+{
+    var isHeroku = Environment.GetEnvironmentVariable("DYNO") != null;
+    if (isHeroku)
+    {
+        options.HttpsPort = 443;
+    };
+});
 builder.Services.AddDbContext<GettingStartedMovieContext>(options =>
 {
     var match = Regex.Match(Environment.GetEnvironmentVariable("DATABASE_URL") ?? "", @"postgres://(.*):(.*)@(.*):(.*)/(.*)");

--- a/Frontend/Program.cs
+++ b/Frontend/Program.cs
@@ -15,6 +15,7 @@ builder.Services.AddHttpsRedirection(options =>
     var isHeroku = Environment.GetEnvironmentVariable("DYNO") != null;
     if (isHeroku)
     {
+        options.RedirectStatusCode = StatusCodes.Status308PermanentRedirect;
         options.HttpsPort = 443;
     };
 });

--- a/Frontend/Program.cs
+++ b/Frontend/Program.cs
@@ -6,7 +6,7 @@ using GettingStarted.Data;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
-var isHeroku = Environment.GetEnvironmentVariable("DYNO") != null;
+var isHeroku = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DYNO"));
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;

--- a/Frontend/Program.cs
+++ b/Frontend/Program.cs
@@ -6,13 +6,18 @@ using GettingStarted.Data;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
+var isHeroku = Environment.GetEnvironmentVariable("DYNO") != null;
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    if (isHeroku)
+    {
+        options.KnownNetworks.Clear();
+        options.KnownProxies.Clear();
+    }
 });
 builder.Services.AddHttpsRedirection(options =>
 {
-    var isHeroku = Environment.GetEnvironmentVariable("DYNO") != null;
     if (isHeroku)
     {
         options.RedirectStatusCode = StatusCodes.Status308PermanentRedirect;


### PR DESCRIPTION
This PR enables processing `X-Forwarded-For` and `X-Forwarded-Proto` headers when we're on Heroku (and can trust the network/proxy), and HTTP requests are redirected to HTTPS with HTTP 308.