### PR TITLE
Explicitly set buildpack when creating app

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Eligible students can apply for platform credits through our new [Heroku for Git
 ```term
 $ git clone https://github.com/heroku/dotnet-getting-started
 $ cd dotnet-getting-started
-$ heroku create
+$ heroku create --buildpack heroku/dotnet
 $ git push heroku main
 $ heroku open
 ```


### PR DESCRIPTION
This is required while the classic buildpack is still in beta