### PR TITLE
Remove dotnet tool restore post-publish target

### DIFF
--- a/Frontend/Frontend.csproj
+++ b/Frontend/Frontend.csproj
@@ -22,8 +22,6 @@
   </ItemGroup>
 
   <Target Name="PostPublishStep" AfterTargets="Publish">
-    <Message Text="Restoring .NET tools" Importance="High" />
-    <Exec Command="dotnet tool restore" />
     <Message Text="Publishing executable database migration bundle" Importance="High" />
     <Exec Command="dotnet ef migrations bundle --output $(PublishDir)/efbundle --force"  />
   </Target>


### PR DESCRIPTION
The .NET buildpacks will now restore .NET tools since https://github.com/heroku/buildpacks-dotnet/pull/194 was introduced in https://github.com/heroku/buildpacks-dotnet/releases/tag/v0.2.2 and https://github.com/heroku/heroku-buildpack-dotnet/releases/tag/v7