### PR TITLE
Disable release phase db migration by default

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,8 @@
 web: cd Frontend/bin/publish/; ./Frontend --urls http://*:$PORT
-release: Frontend/bin/publish/efbundle
+
+# Uncomment this `release` process if you are using a database, so that the efbundle
+# migrations (compiled after building the application) are run as part of app deployment,
+# using Heroku's Release Phase feature:
+# https://learn.microsoft.com/en-us/ef/core/managing-schemas/migrations/applying?tabs=dotnet-core-cli#efbundle
+# https://devcenter.heroku.com/articles/release-phase
+# release: Frontend/bin/publish/efbundle


### PR DESCRIPTION
The Frontend [project compiles an `efbundle`](https://github.com/heroku/dotnet-getting-started/blob/main/Frontend/Frontend.csproj#L24-L27) after publishing the application to allow users to run database migrations during app deployment.

However, deployments will will fail if the application doesn't have a database installed, so disabling it for now.