### PR TITLE
Exclude unnecessary files from local builds

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,16 @@
+[_]
+schema-version = "0.2"
+
+[io.buildpacks]
+# Exclude files from local Pack CLI builds, where .gitignore doesn't apply.
+
+exclude = [
+  ".git",
+  ".gitignore",
+  ".gitattributes",
+  ".github",
+  ".DS_Store",
+  ".env",
+  "bin/",
+  "obj/"
+]


### PR DESCRIPTION
Exclude unnecessary files from images when building locally with `pack build`.

GUS-W-18754502