### PR TITLE
Bump EF Core stack 8.x -> 10.x and regenerate migrations

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "8.0.27",
+      "version": "10.0.8",
       "commands": [
         "dotnet-ef"
       ]

--- a/Frontend/Frontend.csproj
+++ b/Frontend/Frontend.csproj
@@ -24,7 +24,11 @@
 
   <Target Name="PostPublishStep" AfterTargets="Publish">
     <Message Text="Publishing executable database migration bundle" Importance="High" />
-    <Exec Command="dotnet ef migrations bundle --output $(PublishDir)/efbundle --force" />
+    <Exec Command="dotnet ef migrations bundle --output $(PublishDir)/efbundle --force"
+          EnvironmentVariables="ArtifactsPath=$(ArtifactsPath)"
+          Condition="'$(ArtifactsPath)' != ''" />
+    <Exec Command="dotnet ef migrations bundle --output $(PublishDir)/efbundle --force"
+          Condition="'$(ArtifactsPath)' == ''" />
   </Target>
 
 </Project>

--- a/Frontend/Frontend.csproj
+++ b/Frontend/Frontend.csproj
@@ -8,18 +8,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.14.28" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.27">
+    <PackageReference Include="Microsoft.Build" Version="18.4.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.27" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.27">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.23" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
   </ItemGroup>
 
   <Target Name="PostPublishStep" AfterTargets="Publish">

--- a/Frontend/Migrations/20260513095702_InitialCreate.Designer.cs
+++ b/Frontend/Migrations/20260513095702_InitialCreate.Designer.cs
@@ -5,38 +5,45 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace GettingStarted.Migrations
+namespace GettingStarted.Frontend.Migrations
 {
     [DbContext(typeof(GettingStartedMovieContext))]
-    [Migration("20240216004219_InitialCreate")]
+    [Migration("20260513095702_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "8.0.2");
+            modelBuilder
+                .HasAnnotation("ProductVersion", "10.0.8")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("GettingStarted.Models.Movie", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Genre")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<decimal>("Price")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("numeric");
 
-                    b.Property<DateTime>("ReleaseDate")
-                        .HasColumnType("TEXT");
+                    b.Property<DateOnly>("ReleaseDate")
+                        .HasColumnType("date");
 
                     b.Property<string>("Title")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 

--- a/Frontend/Migrations/20260513095702_InitialCreate.cs
+++ b/Frontend/Migrations/20260513095702_InitialCreate.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace GettingStarted.Migrations
+namespace GettingStarted.Frontend.Migrations
 {
     /// <inheritdoc />
     public partial class InitialCreate : Migration
@@ -15,13 +16,12 @@ namespace GettingStarted.Migrations
                 name: "Movie",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true)
-                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityAlwaysColumn),
-                    Title = table.Column<string>(type: "TEXT", nullable: true),
-                    ReleaseDate = table.Column<DateOnly>(type: "DATE", nullable: false),
-                    Genre = table.Column<string>(type: "TEXT", nullable: true),
-                    Price = table.Column<decimal>(type: "NUMERIC", nullable: false)
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Title = table.Column<string>(type: "text", nullable: true),
+                    ReleaseDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    Genre = table.Column<string>(type: "text", nullable: true),
+                    Price = table.Column<decimal>(type: "numeric", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/Frontend/Migrations/GettingStartedMovieContextModelSnapshot.cs
+++ b/Frontend/Migrations/GettingStartedMovieContextModelSnapshot.cs
@@ -4,10 +4,11 @@ using GettingStarted.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace GettingStarted.Migrations
+namespace GettingStarted.Frontend.Migrations
 {
     [DbContext(typeof(GettingStartedMovieContext))]
     partial class GettingStartedMovieContextModelSnapshot : ModelSnapshot
@@ -15,25 +16,31 @@ namespace GettingStarted.Migrations
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "8.0.2");
+            modelBuilder
+                .HasAnnotation("ProductVersion", "10.0.8")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("GettingStarted.Models.Movie", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Genre")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<decimal>("Price")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("numeric");
 
-                    b.Property<DateTime>("ReleaseDate")
-                        .HasColumnType("TEXT");
+                    b.Property<DateOnly>("ReleaseDate")
+                        .HasColumnType("date");
 
                     b.Property<string>("Title")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 


### PR DESCRIPTION
## Summary

- Upgrades EF Core, Npgsql provider, Microsoft.Build, and the dotnet-ef tool from 8.x to 10.x to align with the project's `net10.0` target framework.
- Regenerates the EF migration and model snapshot under EF 10. The previous snapshot was generated by EF 8 (and originally appears to have been scaffolded against SQLite — it carried `INTEGER`/`TEXT` column types and a `Sqlite:Autoincrement` annotation). EF 10 detected this as model drift and emitted `PendingModelChangesWarning`. The new snapshot uses native Postgres types (`integer`/`text`/`date`/`numeric`) and `IdentityByDefaultColumn`.

### Version bumps

| Package | From | To |
|---|---|---|
| Microsoft.Build | 17.14.28 | 18.4.0 |
| Microsoft.EntityFrameworkCore.Design | 8.0.27 | 10.0.8 |
| Microsoft.EntityFrameworkCore.SqlServer | 8.0.27 | 10.0.8 |
| Microsoft.EntityFrameworkCore.Tools | 8.0.27 | 10.0.8 |
| Microsoft.VisualStudio.Web.CodeGeneration.Design | 8.0.23 | 10.0.2 |
| Npgsql.EntityFrameworkCore.PostgreSQL | 8.0.11 | 10.0.1 |
| dotnet-ef (tool) | 8.0.27 | 10.0.8 |